### PR TITLE
修复Linux下无法安装游戏核心的问题、调整autoMake

### DIFF
--- a/WonderLab/App.axaml.cs
+++ b/WonderLab/App.axaml.cs
@@ -80,9 +80,8 @@ namespace WonderLab
 
                     if (InfoConst.IsLinux)
                     {
-                        var info = new ProcessStartInfo($"chmod 777 {PathConst.DownloaderPath}")
+                        var info = new ProcessStartInfo("chmod", $"+x {PathConst.DownloaderPath}")
                         {
-                            FileName = "/bin/bash",
                             RedirectStandardOutput = true
                         };
 

--- a/autoMake
+++ b/autoMake
@@ -1,50 +1,96 @@
 #!/usr/bin/env bash
 
-BINDir=./WonderLab/bin/Debug/net6.0
+set -e
+
+function log()
+{
+    echo "[$(date "+%Y-%m-%d %H:%M:%S")] $*"
+}
+
+function die()
+{
+    local _retValue="${1:-1}"
+    local _msg="${2:-未知原因}"
+
+    log "已退出：${_msg}"
+    exit "${_retValue}"
+}
+
+if [ ! -f "${PWD}/autoMake" ]; then
+    die 114 "请在项目根目录下运行！并使用./autoMake运行。"
+fi
+
+readonly DEBUG="${DEBUG:-false}"
+readonly SINGLEFILE="${SINGLEFILE:-true}"
+
+BUILDTYPE="Unknown"
+
+if [ "${DEBUG}" == "true" ]; then
+    BUILDTYPE="Debug"
+else
+    BUILDTYPE="Release"
+fi
+
+readonly BUILDTYPE
+
 if [ $# -ge 2 ]; then
     Ver=$2
 else
     Ver=1.0.0
 fi
 
-if [ "$0" == ".\/autoMake" ]; then
-    echo "请在项目根目录下运行！并使用./autoMake运行。"
-    exit 114
-fi
+readonly ROOTDIR="${PWD}"
+readonly BINDIR="${ROOTDIR}/WonderLab/bin/${BUILDTYPE}/net6.0"
 
-if [ "$1" == "build" ]; then
-   echo "开始编译"
-   cd WonderLab
-   dotnet build
+function build()
+{
+   log "开始编译"
+   cd "${ROOTDIR}" || die 2 "无法变更目录到 ${ROOTDIR}"
+
+   dotnet build -c "${BUILDTYPE}"
    dotnet deb install
    dotnet rpm install
-   echo "编译结束，输入 autoMake package 以打包。" 
-   exit 0
+   log "编译结束" 
+}
+
+function package()
+{
+    log "开始打包"
+
+    cd "${ROOTDIR}" || die 2 "无法变更目录到 ${ROOTDIR}"
+
+    # 初始化输出目录
+    rm -rf "${_finalDir}"
+    mkdir -vp "${_finalDir}"
+
+    local _targetRuntime="linux-x64"
+    dotnet publish WonderLab -c Release -r "${_targetRuntime}" \
+        --self-contained true \
+        -p:PublishSingleFile="${SINGLEFILE}" \
+        -p:PublishReadyToRun=true \
+        -t:CreateDeb -t:CreateRpm
+
+    local _publishDir="${BINDIR}/${_targetRuntime}/publish"
+    local _finalDir="${ROOTDIR}/bin"
+
+    # 移动deb和rpm包到输出目录中
+    local _archiveName="${BINDIR}/${_targetRuntime}/WonderLab.$Ver.${_targetRuntime}"
+    mv "${_archiveName}.deb" "${_finalDir}/linux-x86_64.deb"
+    mv "${_archiveName}.rpm" "${_finalDir}/linux-x86_64.rpm"
+
+    cd "${_publishDir}" || die 2 "无法变更目录到 ${_publishDir}"
+    tar -zcvf "${_finalDir}/linux-x86_64.tar.gz" ./*
+    log "打包完成！在bin目录下！"
+    exit 0
+}
+
+if [ "$1" == "build" ]; then
+    build
 elif [ "$1" == "package" ]; then
-    echo "开始打包"
-    if [ -d "$BINDir" ]; then
-        cd WonderLab
-        dotnet msbuild ./WonderLabX.csproj /t:CreateDeb
-        dotnet msbuild ./WonderLabX.csproj /t:CreateRpm
-        cd ../$BINDir
-        mv WonderLab.$Ver.deb linux-x86_64.deb
-        mv WonderLab.$Ver.rpm linux-x86_64.rpm
-        cd publish
-        tar -zcvf ../linux-x86_64.tar.gz ./*
-        echo "打包成功，正在移动包"
-        cd ../
-        rm -rf ../../../../bin
-        mkdir ../../../../bin
-        mv ./linux-x86_64.* ../../../../bin
-        cd ../../../../
-        echo "打包完成！在bin目录下！"
-        exit 0
-    fi
-    echo "请先成功编译！"
-    exit 514
+    package
 else
-    echo "帮助："
-    echo "build 编译软件"
-    echo "package 打包软件（须先编译）"
+    log "帮助："
+    log "build 只编译软件"
+    log "package 打包软件"
     exit 1919
 fi


### PR DESCRIPTION
ProcessStartInfo第一个参数是文件名，第二个才是执行参数（

调整后的autoMake可以在构建时生成单文件版本，构建出来的启动器也不需要用户安装.NET运行时